### PR TITLE
Data modeling fixes & normalization conflation 

### DIFF
--- a/Common/utils.py
+++ b/Common/utils.py
@@ -157,13 +157,14 @@ class GetData:
         # return the data stream
         return binary
 
-    def get_ftp_file_date(self, ftp_site, ftp_dir, ftp_file) -> str:
+    def get_ftp_file_date(self, ftp_site, ftp_dir, ftp_file, exclude_day=False) -> str:
         """
         gets the modified date of the file from the ftp site
 
         :param ftp_site:
         :param ftp_dir:
         :param ftp_file:
+        :param exclude_day:
         :return:
         """
         # init the return value
@@ -180,8 +181,13 @@ class GetData:
 
             # did we get something
             if len(date_val) > 0:
-                # return the parsed date
-                return dp.parse(date_val[1]).strftime('%-m_%-d_%Y')
+                if exclude_day:
+                    # if exclude_day format to month_year
+                    file_date = dp.parse(date_val[1]).strftime('%-m_%Y')
+                else:
+                    # otherwise return month_day_year
+                    file_date = dp.parse(date_val[1]).strftime('%-m_%-d_%Y')
+                return file_date
         except Exception as e:
             error_message = f'Error getting modification date for ftp file: {ftp_site}{ftp_dir}{ftp_file}. {e}'
             self.logger.error(error_message)

--- a/graph_specs/yeast-graph-spec.yml
+++ b/graph_specs/yeast-graph-spec.yml
@@ -9,7 +9,7 @@ graphs:
     # graph_description: 'The baseline graph from which RobokopKG and other graphs are built.'
     # conflation: True # (whether to conflate node types like Genes and Proteins)
     graph_name: ROBOKOP Baseline
-    graph_description: 'ROBOKOP (KG) is an open-source biomedical KG that supports the ROBOKOP application. This is the baseline version of that graph, which does not include knowledge sources with specific genetic variants.'
+    graph_description: 'The ROBOKOP Knowledge Graph (ROBOKOP KG) is an open-source biomedical KG that supports the ROBOKOP application and currently contains millions of biomedical relationships derived from dozens of integrated and harmonized biological knowledge sources and bio-ontologies. The ROBOKOP KG includes curated components of most of the Automat KGs, as well as other knowledge sources. Most of the ROBOKOP knowledge sources are curated. However, the ROBOKOP KG also includes text-mined assertions from PubMed and PubMed Central that have been derived from natural language processing (NLP). Note that text-based assertions, while providing valuable information, must be interpreted with caution, as NLP algorithms may introduce false assertions.'
     graph_url: http://robokopkg.renci.org/browser/
     conflation: True
     output_format: neo4j

--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -99,7 +99,7 @@ class ReactomeLoader(SourceDataLoader):
     source_data_url = "https://reactome.org/"
     license = "https://reactome.org/license"
     attribution = "https://academic.oup.com/nar/article/50/D1/D687/6426058?login=false"
-    parsing_version = '1.1'
+    parsing_version = '1.2'
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """

--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -26,8 +26,8 @@ PREDICATE_MAPPING = {"compartment": "biolink:occurs_in",
                      "output": "biolink:has_output",
                      "input": "biolink:has_input",
                      "hasEvent": "biolink:contains_process",
-                     "normalPathway":"biolink:contains_process", #TODO Choose better biolink predicate for normalPathways/Reactions/Etc.
-                     "normalReaction":"biolink:contains_process", #TODO Choose better biolink predicate for normalPathways/Reactions/Etc.
+                     "normalPathway": "biolink:contains_process", #TODO Choose better biolink predicate for normalPathways/Reactions/Etc.
+                     "normalReaction": "biolink:contains_process", #TODO Choose better biolink predicate for normalPathways/Reactions/Etc.
                      #"normalEntity":"biolink:contains_process", #TODO Choose better biolink predicate for normalPathways/Reactions/Etc.
                      "precedingEvent": "biolink:precedes",
                      "activeUnit": "biolink:actively_involves",
@@ -36,9 +36,9 @@ PREDICATE_MAPPING = {"compartment": "biolink:occurs_in",
                      "cellType": "biolink:located_in",
                      "goBiologicalProcess": "biolink:subclass_of",
                      "disease": "biolink:disease_has_basis_in",
-                     "regulator":"biolink:regulates",
-                     "species":"biolink:in_taxon",
-                     "includedLocation":"biolink:located_in"}
+                     "regulator": "biolink:regulates",
+                     "species": "biolink:in_taxon",
+                     "includedLocation": "biolink:located_in"}
 
 
 # TODO - use something like this instead of manipulating strings for individual cases
@@ -301,7 +301,6 @@ class ReactomeLoader(SourceDataLoader):
         skipped_record_count = 0
         for record in result:
             record_data = record.data()
-
             node_a_id = self.process_node_from_neo4j(reference_entity_mapping, record_data['a_id'], record_data['a'], record_data['a_labels'])
             node_b_id = self.process_node_from_neo4j(reference_entity_mapping, record_data['b_id'], record_data['b'], record_data['b_labels'])
             if node_a_id and node_b_id:
@@ -310,19 +309,19 @@ class ReactomeLoader(SourceDataLoader):
                         self.process_edge_from_neo4j(node_a_id,
                                                      record_data['r_type'],
                                                      node_b_id,
-                                                     regulationType='positive',
+                                                     regulation_type='positive',
                                                      complex_context=record_data.get('complex_context', None))
                     elif any("negative" in x.lower() for x in record_data['regulationType']):
                         self.process_edge_from_neo4j(node_a_id,
                                                      record_data['r_type'],
                                                      node_b_id,
-                                                     regulationType='negative',
+                                                     regulation_type='negative',
                                                      complex_context=record_data.get('complex_context', None))
                 else:
                     self.process_edge_from_neo4j(node_a_id,
                                                  record_data['r_type'],
                                                  node_b_id,
-                                                 regulationType=None,
+                                                 regulation_type=None,
                                                  complex_context=record_data.get('complex_context', None))
                 record_count += 1
             else:
@@ -417,10 +416,15 @@ class ReactomeLoader(SourceDataLoader):
         self.dbid_to_node_id_lookup[node['dbId']] = node_id
         """
 
-    def process_edge_from_neo4j(self, subject_id: str, relationship_type: str, object_id: str, regulationType=None, complex_context=None):
+    def process_edge_from_neo4j(self,
+                                subject_id: str,
+                                relationship_type: str,
+                                object_id: str,
+                                regulation_type=None,
+                                complex_context=None):
         predicate = PREDICATE_MAPPING.get(relationship_type, None)
         if predicate:
-            if regulationType is None:
+            if not regulation_type:
                 output_edge = kgxedge(
                     subject_id=subject_id,
                     object_id=object_id,
@@ -429,14 +433,16 @@ class ReactomeLoader(SourceDataLoader):
                     primary_knowledge_source=self.provenance_id
                 )
             else:
-                if regulationType == 'positive':
+                if regulation_type == 'positive':
                     direction = 'upregulated'
-                elif regulationType == 'negative':
+                elif regulation_type == 'negative':
                     direction = 'downregulated'
                 else:
-                    self.logger.warning(f'Unexpected regulation type encountered: {regulationType}')
+                    self.logger.warning(f'Unexpected regulation type encountered: {regulation_type}')
                     return
                 edge_props = {
+                    'qualified_predicate': 'causes',
+                    'object_aspect': 'activity',
                     'object_direction_qualifier': direction,
                 }
                 if complex_context:

--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -429,14 +429,15 @@ class ReactomeLoader(SourceDataLoader):
                     primary_knowledge_source=self.provenance_id
                 )
             else:
-                if regulationType == "positive":
-                    direction = 'increased'
-                elif regulationType == "negative":
-                    direction = 'decreased'
+                if regulationType == 'positive':
+                    direction = 'upregulated'
+                elif regulationType == 'negative':
+                    direction = 'downregulated'
+                else:
+                    self.logger.warning(f'Unexpected regulation type encountered: {regulationType}')
+                    return
                 edge_props = {
-                    'qualified_predicate': 'biolink:causes',
                     'object_direction_qualifier': direction,
-                    'object_aspect_qualifier': 'expression',
                 }
                 if complex_context:
                     edge_props['complex_context'] = complex_context

--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -36,7 +36,7 @@ PREDICATE_MAPPING = {"compartment": "biolink:occurs_in",
                      "cellType": "biolink:located_in",
                      "goBiologicalProcess": "biolink:subclass_of",
                      "disease": "biolink:disease_has_basis_in",
-                     "regulator": "biolink:regulates",
+                     "regulator": "biolink:affects",
                      "species": "biolink:in_taxon",
                      "includedLocation": "biolink:located_in"}
 
@@ -434,15 +434,15 @@ class ReactomeLoader(SourceDataLoader):
                 )
             else:
                 if regulation_type == 'positive':
-                    direction = 'upregulated'
+                    direction = 'increased'
                 elif regulation_type == 'negative':
-                    direction = 'downregulated'
+                    direction = 'decreased'
                 else:
                     self.logger.warning(f'Unexpected regulation type encountered: {regulation_type}')
                     return
                 edge_props = {
                     'qualified_predicate': 'causes',
-                    'object_aspect': 'activity',
+                    'object_aspect': 'expression',
                     'object_direction_qualifier': direction,
                 }
                 if complex_context:

--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -442,7 +442,7 @@ class ReactomeLoader(SourceDataLoader):
                     return
                 edge_props = {
                     'qualified_predicate': 'causes',
-                    'object_aspect': 'expression',
+                    'object_aspect_qualifier': 'expression',
                     'object_direction_qualifier': direction,
                 }
                 if complex_context:

--- a/parsers/chebi/src/loadChebiProperties.py
+++ b/parsers/chebi/src/loadChebiProperties.py
@@ -1,6 +1,6 @@
 import os
 import argparse
-from gzip import GzipFile
+import gzip
 
 from collections import defaultdict
 from Common.utils import GetData
@@ -30,13 +30,14 @@ CHEBI_ROLES_TO_IGNORE = ["CHEBI:50906",  # role
 class ChebiPropertiesLoader(SourceDataLoader):
 
     # Setting the class level variables for the source ID and provenance
-    source_id: str = 'ChebiProperties'
-    provenance_id: str = 'infores:chebi-properties'
-    description = ""
-    source_data_url = ""
+    source_id: str = 'CHEBIProps'
+    provenance_id: str = None  # there aren't edges coming from this source currently
+    description = "Chemical Entities of Biological Interest (ChEBI) is a freely available dictionary of molecular " \
+                  "entities focused on ‘small’ chemical compounds."
+    source_data_url = "https://www.ebi.ac.uk/chebi/"
     license = ""
     attribution = ""
-    parsing_version = '1.1'
+    parsing_version = '1.2'
     preserve_unconnected_nodes = True
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
@@ -87,18 +88,17 @@ class ChebiPropertiesLoader(SourceDataLoader):
         names = {}
         skipped_header = False
         archive_file_path = os.path.join(self.data_path, self.compounds_file)
-        with GzipFile(archive_file_path) as zf:
-            for bytesline in zf:
+        with gzip.open(archive_file_path, mode="rt", encoding="iso-8859-1") as zf:
+            for line in zf:
 
                 # skip the header
                 if not skipped_header:
                     skipped_header = True
                     continue
 
-                lines = bytesline.decode('utf-8')
-                line = lines.strip().split('\t')
-                chebi_id = line[COMPOUNDS_CHEBI_ID_COLUMN]
-                cname = line[COMPOUNDS_CHEBI_NAME_COLUMN]
+                compounds_line = line.strip().split('\t')
+                chebi_id = compounds_line[COMPOUNDS_CHEBI_ID_COLUMN]
+                cname = compounds_line[COMPOUNDS_CHEBI_NAME_COLUMN]
                 names[chebi_id] = cname
 
         # init the record counters

--- a/parsers/hgnc/src/loadHGNC.py
+++ b/parsers/hgnc/src/loadHGNC.py
@@ -46,9 +46,12 @@ class HGNCLoader(SourceDataLoader):
 
         :return: the data version
         """
-
         data_puller = GetData()
-        data_file_date = data_puller.get_ftp_file_date(self.ftp_site, self.ftp_dir, self.data_files[0])
+        # HGNC files change very frequently, excluding the day makes sure we only update it once per month
+        data_file_date = data_puller.get_ftp_file_date(self.ftp_site,
+                                                       self.ftp_dir,
+                                                       self.data_files[0],
+                                                       exclude_day=True)
         return data_file_date
 
     def get_data(self) -> int:

--- a/parsers/hmdb/src/loadHMDB.py
+++ b/parsers/hmdb/src/loadHMDB.py
@@ -1,6 +1,5 @@
 import os
 import argparse
-import logging
 import requests
 import re
 import xml.etree.cElementTree as E_Tree
@@ -25,10 +24,10 @@ class HMDBLoader(SourceDataLoader):
     source_id: str = 'HMDB'
     provenance_id: str = 'infores:hmdb'
     description = "The Human Metabolome Database (HMDB) is an openly accessible database containing detailed information about small molecule metabolites found in the human body, with links between chemical data, clinical data, and molecular biology/biochemistry data, including protein sequences (enzymes and transporters)."
-    source_data_url = "https://translator.ncats.io/hmdb-knowledge-beacon"
+    source_data_url = "https://hmdb.ca/downloads"
     license = "https://hmdb.ca/about"
     attribution = "https://hmdb.ca/about#cite"
-    parsing_version: str = '1.1'
+    parsing_version: str = '1.2'
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """
@@ -36,21 +35,8 @@ class HMDBLoader(SourceDataLoader):
         :param source_data_dir - the specific storage directory to save files in
         """
         super().__init__(test_mode=test_mode, source_data_dir=source_data_dir)
-
-        # set global variables
-        self.data_file: str = 'hmdb_metabolites.zip'
-        self.source_db: str = 'Human Metabolome Database'
-
-        # create a logger
-        self.logger = LoggingUtil.init_logging("Data_services.HMDB.HMDBLoader", level=logging.INFO, line_format='medium', log_file_path=os.environ['DATA_SERVICES_LOGS'])
-
-    def get_name(self):
-        """
-        returns the name of the class
-
-        :return: str - the name of the class
-        """
-        return self.__class__.__name__
+        self.data_file = 'hmdb_metabolites.zip'
+        self.data_url = 'https://hmdb.ca/system/downloads/current/'
 
     def get_latest_source_version(self) -> str:
         """
@@ -58,43 +44,23 @@ class HMDBLoader(SourceDataLoader):
 
         :return:
         """
-        # init the return
+        # this grabs the html from the downloads page and searches for the Current Version on it
         ret_val: str = 'Not found'
-
-        # load the web page for CTD
         html_page: requests.Response = requests.get('https://hmdb.ca/downloads')
-
-        # get the html into a parsable object
         resp: BeautifulSoup = BeautifulSoup(html_page.content, 'html.parser')
-
-        # init the search text
         search_text = 'Current Version '
-
-        # find the version div area
         div_tag = resp.find('a', string=re.compile('Current Version'))
-
-        # did we find version data
         if len(div_tag) > 0:
             ret_val = div_tag.text.split(search_text)[1].strip('() ')
-
-        # return to the caller
         return ret_val
 
     def get_data(self) -> int:
         """
         Gets the hmdb data.
-
         """
-        # get a reference to the data gathering class
         gd: GetData = GetData(self.logger.level)
-
-        # do the real thing if we arent in debug mode
-        if not self.test_mode:
-            byte_count: int = gd.pull_via_http('https://hmdb.ca/system/downloads/current/hmdb_metabolites.zip', self.data_path)
-        else:
-            byte_count: int = 1
-
-        # return the file count to the caller
+        byte_count: int = gd.pull_via_http(f'{self.data_url}{self.data_file}',
+                                           self.data_path)
         return byte_count
 
     def parse_data(self) -> dict:
@@ -233,8 +199,8 @@ class HMDBLoader(SourceDataLoader):
                         if protein_type.text.startswith('Enzyme'):
                             # create the edge data
                             props: dict = {}
-                            subject_id: str = protein_id
-                            object_id: str = metabolite_id
+                            subject_id: str = metabolite_id
+                            object_id: str = protein_id
                             predicate: str = f'{CTD}:affects_abundance_of'
                         # else it must be a transport?
                         else:


### PR DESCRIPTION
- turned on drug chemical conflation during normalization (as well as gene protein) when conflation is requested 
- implemented retries for 5xx errors from the node normalizer service
- fixed a data modeling issue in Reactome where regulates edges had a mismatch between qualifiers and the predicate
- changed HGNC version detection to use just month and year and not days to prevent excessive updating
- fixed a bug in chebi properties where certain characters in new versions needed to be encoded in something other than the default (iso-8859-1 seems to work)
- fixed a bug in HMDB where some affects_abundance_of edges were pointing in the wrong direction
