### PR TITLE
fixing publications issues 

### DIFF
--- a/parsers/SGD/src/loadSGD.py
+++ b/parsers/SGD/src/loadSGD.py
@@ -87,7 +87,7 @@ class SGDLoader(SourceDataLoader):
 
     source_id: str = 'SGD'
     provenance_id: str = 'infores:sgd'
-    parsing_version = '1.1'
+    parsing_version = '1.2'
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """
@@ -179,7 +179,8 @@ class SGDLoader(SourceDataLoader):
                                   lambda line: {'evidenceCode': line[GENEGOTERMS_EDGEUMAN.EVIDENCECODE.value],
                                                 'evidenceCodeText': line[GENEGOTERMS_EDGEUMAN.EVIDENCECODETEXT.value],
                                                 'annotationType': line[GENEGOTERMS_EDGEUMAN.ANNOTATIONTYPE.value],
-                                                PUBLICATIONS: [f'{PUBMED}:{line[GENEGOTERMS_EDGEUMAN.EVIDENCEPMID.value]}'],
+                                                PUBLICATIONS: [f'{PUBMED}:{line[GENEGOTERMS_EDGEUMAN.EVIDENCEPMID.value]}']
+                                                if line[GENEGOTERMS_EDGEUMAN.EVIDENCEPMID.value] != "?" else [],
                                                 PRIMARY_KNOWLEDGE_SOURCE: self.provenance_id
                                              }, #edgeprops
                                   comment_character=None,
@@ -226,7 +227,8 @@ class SGDLoader(SourceDataLoader):
                                                 'yeastStrainBackground': line[GENEPHENOTYPES_EDGEUMAN.STRAINBACKGROUND.value],
                                                 'chemicalExposure': line[GENEPHENOTYPES_EDGEUMAN.CHEMICAL.value],
                                                 'experimentalCondition': line[GENEPHENOTYPES_EDGEUMAN.CONDITION.value],
-                                                PUBLICATIONS: [f'{PUBMED}:{line[GENEPHENOTYPES_EDGEUMAN.EVIDENCEPMID.value]}'],
+                                                PUBLICATIONS: [f'{PUBMED}:{line[GENEPHENOTYPES_EDGEUMAN.EVIDENCEPMID.value]}']
+                                                if line[GENEPHENOTYPES_EDGEUMAN.EVIDENCEPMID.value] != "?" else [],
                                                 PRIMARY_KNOWLEDGE_SOURCE: self.provenance_id}, #edgeprops
                                   comment_character=None,
                                   delim=',',

--- a/parsers/SGD/src/sgd_source_retriever.py
+++ b/parsers/SGD/src/sgd_source_retriever.py
@@ -42,7 +42,7 @@ def SGDGene2GOTerm(data_directory):
                                 quotechar='"', quoting=csv.QUOTE_MINIMAL)
         for row in reader:
             datawriter.writerow(row)
-    gene2gotermdf = pd.read_csv(os.path.join(storage_dir, csv_fname))
+    gene2gotermdf = pd.read_csv(os.path.join(storage_dir, csv_fname), dtype="string")
     gene2gotermdf.columns = view
     gene2gotermdf[view[0]] = gene2gotermdf[view[0]].apply(lambda x: "SGD:" + str(x))
     gene2gotermdf.fillna("?", inplace=True)
@@ -70,7 +70,7 @@ def SGDGene2Phenotype(data_directory):
                 'identifier': identifiers,
                 'reference': references}
 
-    apodf = pd.DataFrame(data=apo_dict)
+    apodf = pd.DataFrame(data=apo_dict, dtype="string")
     print('APO IDs Collected!')
     csv_fname = 'yeast_phenotype_APO_identifiers.csv'
     storage_dir = data_directory
@@ -105,7 +105,7 @@ def SGDGene2Phenotype(data_directory):
 
     # Join SGD data to APO identifiers and save file in current directory
     print("Joining APO IDs and SGD links to gene2phenotype table and saving...")
-    gene2phenotypedf = pd.read_csv(os.path.join(storage_dir, csv_fname))
+    gene2phenotypedf = pd.read_csv(os.path.join(storage_dir, csv_fname), dtype="string")
 
     gene2phenotypedf.columns = view
     gene2phenotypedf[view[0]] = gene2phenotypedf[view[0]].apply(lambda x: "SGD:" + str(x))


### PR DESCRIPTION
SGD had two issues with publications related to pandas..

null values were converted to "?" which resulted in:
"publications": ["PMID:?"]

and pandas was converting the PMIDs to floats which resulted in:
"publications": ["PMID:2404611.0"]

this PR removes entries with only ? and declares the whole pandas dfs as strings so they don't get treated as floats, @beasleyjonm might want to confirm that all fields in gene 2 phenotypes and gene 2 go term are ok to be strings and not numbers, otherwise we'll need to declare types in the pandas dfs for each field