### PR TITLE
Added aggregator_knowledge_sources for Automat-CAM-KP

### DIFF
--- a/parsers/camkp/src/loadCAMKP.py
+++ b/parsers/camkp/src/loadCAMKP.py
@@ -49,6 +49,15 @@ class CAMKPLoader(SourceDataLoader):
         self.data_file: str = 'cam-kg.tsv.gz'
         self.version_file = 'cam-kg.yaml'
 
+        # Every edge from CAM-KP is being aggregated by
+        # CAM-KP (https://github.com/NCATSTranslator/Translator-All/wiki/CAM-Provider-KG), which
+        # is itself aggregated by Automat-CAM-KP (https://github.com/NCATSTranslator/Translator-All/wiki/Automat).
+        self.aggregator_knowledge_sources = [
+            'infores:cam-kp',
+            'infores:automat-cam-kp'
+        ]
+
+
     def get_latest_source_version(self) -> str:
         """
         gets the version of the data
@@ -113,6 +122,7 @@ class CAMKPLoader(SourceDataLoader):
                                    object_id=object_id,
                                    predicate=predicate,
                                    primary_knowledge_source=edge_provenance_id,
+                                   aggregator_knowledge_sources=self.aggregator_knowledge_sources,
                                    edgeprops=edge_properties)
                 self.output_file_writer.write_kgx_edge(new_edge)
 


### PR DESCRIPTION
Automat-CAM-KP sources currently look like this:

```
[ 
     { 
         "resource_id": "infores:go-cam", 
         "resource_role": "primary_knowledge_source", 
         "upstream_resource_ids": None, 
     }, 
     { 
         "resource_id": "infores:automat-cam-kp", 
         "resource_role": "aggregator_knowledge_source", 
         "upstream_resource_ids": ["infores:go-cam"], 
     }, 
 ] 
```

However, we would like to clarify that [`infores:cam-kp`](https://github.com/NCATSTranslator/Translator-All/wiki/CAM-Provider-KG) should be treated as an intermediate aggregator knowledge source between the primary KS and Automat. So we would like the output to look like this:

```
[ 
     { 
         "resource_id": "infores:go-cam", 
         "resource_role": "primary_knowledge_source"
     }, 
     { 
         "resource_id": "infores:cam-kp", 
         "resource_role": "aggregator_knowledge_source", 
         "upstream_resource_ids": ["infores:go-cam"], 
     }, 
     { 
         "resource_id": "infores:automat-cam-kp", 
         "resource_role": "aggregator_knowledge_source", 
         "upstream_resource_ids": ["infores:cam-kp"], 
     }, 
 ]
```

I've tried to do that in this PR, but I have three questions:
1. Is this the correct way to use kgxedge.aggregator_knowledge_sources? I've tried to follow the usage in e.g. [the MonarchKG parser](https://github.com/RobokopU24/ORION/blob/d0ca2762ea96d12e5fd8020ff4fcb4044d5c4ed7/parsers/monarchkg/src/loadMonarchKG.py#L108), but I might have got something wrong.
2. Do I need to specify `infores:automat-cam-kp` as an aggregator source, or is that added automatically?
3. Is it possible to get each aggregator to reference the previous one in the `upstream_resource_ids` as I've specified above? Or will they all have `"upstream_resource_ids": ["infores:go-cam"]` as the sole primary knowledge source?

You can see our discussion about this issue at https://github.com/ExposuresProvider/cam-pipeline/issues/118#issuecomment-1908569248