### PR TITLE
Subclass loops and qualifier merging

### DIFF
--- a/Common/biolink_constants.py
+++ b/Common/biolink_constants.py
@@ -181,3 +181,6 @@ BIOLINK_PROPERTIES_THAT_ARE_LISTS = [
     PUBLICATIONS,
     XREFS
 ]
+
+# biolink compliant predicates
+SUBCLASS_OF = 'biolink:subclass_of'

--- a/Common/merging.py
+++ b/Common/merging.py
@@ -2,16 +2,20 @@ import os
 import jsonlines
 import secrets
 from xxhash import xxh64_hexdigest
+from Common.biolink_utils import get_biolink_model_toolkit
 from Common.biolink_constants import *
 from Common.utils import quick_json_loads, quick_json_dumps, chunk_iterator
 
 NODE_PROPERTIES_THAT_SHOULD_BE_SETS = {SYNONYMS, NODE_TYPES, SYNONYM}
 EDGE_PROPERTIES_THAT_SHOULD_BE_SETS = {AGGREGATOR_KNOWLEDGE_SOURCES, PUBLICATIONS, XREFS}
 
+bmt = get_biolink_model_toolkit()
+
 
 def edge_key_function(edge):
+    qualifiers = [f'{key}{value}' for key, value in edge.items() if bmt.is_qualifier(key)]
     return xxh64_hexdigest(f'{edge[SUBJECT_ID]}{edge[PREDICATE]}{edge[OBJECT_ID]}'
-                           f'{edge.get(PRIMARY_KNOWLEDGE_SOURCE, "")}')
+                           f'{edge.get(PRIMARY_KNOWLEDGE_SOURCE, "")}{"".join(qualifiers)}')
 
 
 def entity_merging_function(entity_1, entity_2, properties_that_are_sets):

--- a/Common/normalization.py
+++ b/Common/normalization.py
@@ -7,7 +7,7 @@ from robokop_genetics.genetics_normalization import GeneticsNormalizer
 from Common.biolink_constants import *
 from Common.utils import LoggingUtil
 
-NORMALIZATION_CODE_VERSION = '1.1'
+NORMALIZATION_CODE_VERSION = '1.2'
 
 # node property name for node types that did not normalize
 CUSTOM_NODE_TYPES = 'custom_node_types'

--- a/helm/orion/renci-values.yaml
+++ b/helm/orion/renci-values.yaml
@@ -57,9 +57,13 @@ pharos:
   db_name: PHAROS
 
 drugcentral:
-  host: pod-host-or-ip
-  port: 5432
-  user: dc-user
-  password: dc-pass
+  host: unmtid-dbs.net
+  port: 5433
+  user: drugman
+  password: dosage
   db_name: drugcentral
+  # host: pod-host-or-ip
+  # port: 5432
+  # user: dc-user
+  # password: dc-pass
 

--- a/parsers/PHAROS/src/loadPHAROS.py
+++ b/parsers/PHAROS/src/loadPHAROS.py
@@ -62,6 +62,24 @@ class PHAROSLoader(SourceDataLoader):
         'UniProt Disease': 'infores:uniprot'
     }
 
+    # we might want more granularity here but for now it's one-to-one source with KL/AT
+    PHAROS_KL_AT_lookup = {
+        'CTD': (PREDICATION, MANUAL_AGENT),
+        'DisGeNET': (NOT_PROVIDED, NOT_PROVIDED),
+        'DrugCentral Indication': (KNOWLEDGE_ASSERTION, MANUAL_AGENT),
+        'eRAM': (NOT_PROVIDED, NOT_PROVIDED),
+        'JensenLab Experiment TIGA': (PREDICATION, AUTOMATED_AGENT),
+        'JensenLab Knowledge AmyCo': (NOT_PROVIDED, NOT_PROVIDED),
+        'JensenLab Knowledge MedlinePlus': (NOT_PROVIDED, NOT_PROVIDED),
+        'JensenLab Knowledge UniProtKB-KW': (NOT_PROVIDED, NOT_PROVIDED),
+        'JensenLab Text Mining': (NOT_PROVIDED, NOT_PROVIDED),
+        'Monarch': (NOT_PROVIDED, NOT_PROVIDED),
+        'UniProt Disease': (KNOWLEDGE_ASSERTION, MANUAL_AGENT)
+    }
+
+    # these are used for pharos edges which are not from a further upstream source
+    PHAROS_KL_AT = (KNOWLEDGE_ASSERTION, MANUAL_AGENT)
+
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """
         :param test_mode - sets the run into test mode
@@ -162,8 +180,9 @@ class PHAROSLoader(SourceDataLoader):
             disease_id = item['did']
             disease_name = self.sanitize_name(item['name'])
             edge_provenance = self.PHAROS_INFORES_MAPPING[item['dtype']]
-            edge_properties = {KNOWLEDGE_LEVEL: NOT_PROVIDED,
-                               AGENT_TYPE: NOT_PROVIDED}
+            knowledge_level, agent_type = self.PHAROS_KL_AT_lookup.get(item['dtype'], (NOT_PROVIDED, NOT_PROVIDED))
+            edge_properties = {KNOWLEDGE_LEVEL: knowledge_level,
+                               AGENT_TYPE: agent_type}
             if item['score']:
                 edge_properties['score'] = float(item['score'])
 
@@ -349,8 +368,9 @@ class PHAROSLoader(SourceDataLoader):
         else:
             pmids: list = []
 
-        props: dict = {KNOWLEDGE_LEVEL: NOT_PROVIDED,
-                       AGENT_TYPE: NOT_PROVIDED}
+        knowledge_level, agent_type = self.PHAROS_KL_AT
+        props: dict = {KNOWLEDGE_LEVEL: knowledge_level,
+                       AGENT_TYPE: agent_type}
 
         # if there was affinity data save it
         affinity = result['affinity']


### PR DESCRIPTION
Implemented the removal of subclass loop edges

Implemented including qualifiers and their values in the edge merging strategy, do not merge edges with conflicting qualifiers.

Added knowledge level and agent type to PHAROS.

Added public instance of drug central as the default db in the helm chart.