### PR TITLE
Convert activity type mapping to log-scale.

### DIFF
--- a/parsers/BINDING/src/loadBINDINGDB.py
+++ b/parsers/BINDING/src/loadBINDINGDB.py
@@ -11,7 +11,8 @@ from parsers.BINDING.src.bindingdb_constraints import LOG_SCALE_AFFINITY_THRESHO
 from Common.utils import GetData, GetDataPullError
 from Common.loader_interface import SourceDataLoader
 from Common.extractor import Extractor
-from Common.biolink_constants import PUBLICATIONS, AFFINITY, AFFINITY_PARAMETER, KNOWLEDGE_LEVEL, AGENT_TYPE, KNOWLEDGE_ASSERTION, MANUAL_AGENT
+from Common.biolink_constants import PUBLICATIONS, AFFINITY, AFFINITY_PARAMETER, KNOWLEDGE_LEVEL, AGENT_TYPE, \
+    KNOWLEDGE_ASSERTION, MANUAL_AGENT
 
 # Full Binding Data.
 

--- a/parsers/PHAROS/src/loadPHAROS.py
+++ b/parsers/PHAROS/src/loadPHAROS.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 import re
-import requests
 
 from Common.loader_interface import SourceDataLoader, SourceDataBrokenError, SourceDataFailedError
 from Common.kgxmodel import kgxnode, kgxedge
@@ -386,11 +385,11 @@ class PHAROSLoader(SourceDataLoader):
         # if there was affinity data save it
         affinity = result['affinity']
         if affinity is not None and affinity != '':
-            props['affinity'] = float(affinity)
+            props[AFFINITY] = float(affinity)
 
         affinity_paramater = result['affinity_parameter']
         if affinity_paramater:
-            props['affinity_parameter'] = f'p{result["affinity_parameter"]}'
+            props[AFFINITY_PARAMETER] = f'p{result["affinity_parameter"]}'
 
         # return to the caller
         return predicate, pmids, props, provenance

--- a/parsers/drugcentral/src/loaddrugcentral.py
+++ b/parsers/drugcentral/src/loaddrugcentral.py
@@ -269,11 +269,11 @@ def get_bioactivity_predicate(line):
         'RELEASING AGENT':'biolink:interacts_with'}
 
             act_type_mappings = {
-        'IC50':'biolink:decreases_activity_of',
-        'Kd':'biolink:interacts_with',
-        'AC50':'biolink:increases_activity_of',
-        'Ki':'biolink:decreases_activity_of',
-        'EC50':'biolink:increases_activity_of'
+        'pIC50':'biolink:decreases_activity_of',
+        'pKd':'biolink:interacts_with',
+        'pAC50':'biolink:increases_activity_of',
+        'pKi':'biolink:decreases_activity_of',
+        'pEC50':'biolink:increases_activity_of'
     }
     """
 

--- a/parsers/drugcentral/src/loaddrugcentral.py
+++ b/parsers/drugcentral/src/loaddrugcentral.py
@@ -8,7 +8,7 @@ from Common.extractor import Extractor
 from Common.loader_interface import SourceDataLoader, SourceDataFailedError, SourceDataBrokenError
 from Common.utils import GetData, snakify
 from Common.biolink_constants import PRIMARY_KNOWLEDGE_SOURCE, AGGREGATOR_KNOWLEDGE_SOURCES, PUBLICATIONS, \
-    KNOWLEDGE_LEVEL, KNOWLEDGE_ASSERTION, AGENT_TYPE, MANUAL_AGENT
+    KNOWLEDGE_LEVEL, KNOWLEDGE_ASSERTION, AGENT_TYPE, MANUAL_AGENT, AFFINITY, AFFINITY_PARAMETER
 from Common.prefixes import DRUGCENTRAL, MEDDRA, UMLS, UNIPROTKB, PUBMED
 from Common.predicates import DGIDB_PREDICATE_MAPPING
 from Common.db_connectors import PostgresConnector
@@ -186,8 +186,8 @@ class DrugCentralLoader(SourceDataLoader):
         edge_props = {KNOWLEDGE_LEVEL: KNOWLEDGE_ASSERTION,
                       AGENT_TYPE: MANUAL_AGENT}
         if line['act_type'] is not None:
-            edge_props['affinity'] = line['act_value']
-            edge_props['affinityParameter'] = f"p{line['act_type']}"
+            edge_props[AFFINITY] = line['act_value']
+            edge_props[AFFINITY_PARAMETER] = f"p{line['act_type']}"
         if line['act_source'] == 'SCIENTIFIC LITERATURE' and line['act_source_url'] is not None:
             papersource = line['act_source_url']
             if papersource.startswith('http://www.ncbi.nlm.nih.gov/pubmed'):

--- a/parsers/drugcentral/src/loaddrugcentral.py
+++ b/parsers/drugcentral/src/loaddrugcentral.py
@@ -187,7 +187,7 @@ class DrugCentralLoader(SourceDataLoader):
                       AGENT_TYPE: MANUAL_AGENT}
         if line['act_type'] is not None:
             edge_props['affinity'] = line['act_value']
-            edge_props['affinityParameter'] = line['act_type']
+            edge_props['affinityParameter'] = f"p{line['act_type']}"
         if line['act_source'] == 'SCIENTIFIC LITERATURE' and line['act_source_url'] is not None:
             papersource = line['act_source_url']
             if papersource.startswith('http://www.ncbi.nlm.nih.gov/pubmed'):
@@ -269,11 +269,11 @@ def get_bioactivity_predicate(line):
         'RELEASING AGENT':'biolink:interacts_with'}
 
             act_type_mappings = {
-        'pIC50':'biolink:decreases_activity_of',
-        'pKd':'biolink:interacts_with',
-        'pAC50':'biolink:increases_activity_of',
-        'pKi':'biolink:decreases_activity_of',
-        'pEC50':'biolink:increases_activity_of'
+        'IC50':'biolink:decreases_activity_of',
+        'Kd':'biolink:interacts_with',
+        'AC50':'biolink:increases_activity_of',
+        'Ki':'biolink:decreases_activity_of',
+        'EC50':'biolink:increases_activity_of'
     }
     """
 


### PR DESCRIPTION
The activity and potency types on Drug Central are log-scaled, so let's add the "p" in front of the activity types to reflect that.