### PR TITLE
A new causal mechanism qualifier for "guanyl_nucleotide_exchange" was…

### DIFF
--- a/parsers/SIGNOR/src/signor_mechanism_predicate_mapping.py
+++ b/parsers/SIGNOR/src/signor_mechanism_predicate_mapping.py
@@ -71,6 +71,9 @@ mechanism_map = {
 
             # This probably needs to be a node property.
             "guanine nucleotide exchange factor": {
+            	"edge_properties": {
+                                    CAUSAL_MECHANISM_QUALIFIER: "guanyl_nucleotide_exchange"
+		}
             },
 
             "post transcriptional modification": {


### PR DESCRIPTION
… added to Biolink

This helps address one of the gaps seen in the SIGNOR database edge properties.
For reference: https://github.com/biolink/biolink-model/pull/1538