### PR TITLE
Extractor syntax updates

### DIFF
--- a/Common/extractor.py
+++ b/Common/extractor.py
@@ -1,4 +1,3 @@
-import csv
 from Common.kgxmodel import kgxnode, kgxedge
 from Common.kgx_file_writer import KGXFileWriter
 from Common.biolink_constants import PRIMARY_KNOWLEDGE_SOURCE, AGGREGATOR_KNOWLEDGE_SOURCES
@@ -82,12 +81,12 @@ class Extractor:
 
     def json_extract(self,
                      json_array,
-                     subject_extractor,
-                     object_extractor,
-                     predicate_extractor,
-                     subject_property_extractor,
-                     object_property_extractor,
-                     edge_property_extractor,
+                     subject_extractor=lambda e: e.get('subject'),
+                     object_extractor=lambda e: e.get('object'),
+                     predicate_extractor=lambda e: e.get('predicate'),
+                     subject_property_extractor=lambda e: e.get('subject_properties'),
+                     object_property_extractor=lambda e: e.get('object_properties'),
+                     edge_property_extractor=lambda e: e.get('edge_properties'),
                      exclude_unconnected_nodes=False):
         for item in json_array:
             self.load_metadata['record_counter'] += 1

--- a/Common/extractor.py
+++ b/Common/extractor.py
@@ -66,7 +66,7 @@ class Extractor:
                 self.load_metadata['errors'].append(e.__str__())
                 self.load_metadata['skipped_record_counter'] += 1
 
-    def sql_extract(self, cursor, sql_query, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor):
+    def sql_extract(self, cursor, sql_query, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor, exclude_unconnected_nodes=False):
         """Read a csv, perform callbacks to retrieve node and edge info per row.
         Assumes that all of the properties extractable for a node occur on the line with the node identifier"""
 
@@ -75,7 +75,7 @@ class Extractor:
         for row in rows:
             self.load_metadata['record_counter'] += 1
             try:
-                self.parse_row(row, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor)
+                self.parse_row(row, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor, exclude_unconnected_nodes)
             except Exception as e:
                 self.load_metadata['errors'].append(e.__str__())
                 self.load_metadata['skipped_record_counter'] += 1
@@ -87,11 +87,12 @@ class Extractor:
                      predicate_extractor,
                      subject_property_extractor,
                      object_property_extractor,
-                     edge_property_extractor):
+                     edge_property_extractor,
+                     exclude_unconnected_nodes=False):
         for item in json_array:
             self.load_metadata['record_counter'] += 1
             try:
-                self.parse_row(item, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor)
+                self.parse_row(item, subject_extractor, object_extractor, predicate_extractor, subject_property_extractor, object_property_extractor, edge_property_extractor, exclude_unconnected_nodes)
             except Exception as e:
                 self.load_metadata['errors'].append(e.__str__())
                 self.load_metadata['skipped_record_counter'] += 1


### PR DESCRIPTION
* First commit includes the `excludes_unconnected_nodes` option to `sql_extract` and
  `json_extract` (both of which end up being passed to `parse_row`. This functionality
  improves consistency with `csv_extract`, which is able to use this option already.
* Second commit makes it more convenient to use json_extract in a concise way by providing
  some sensible defaults if the calling code is already passing in objects with appropriately-
  named keys.

Both of these are designed to be completely backwards compatible, so should not affect any existing code.

As an aside, I note that `json_extract` is probably not appropriately named. It actually doesn't process a "jsonl" file-- it doesn't really handle json at all but rather treats the `json_array` value as a list of python objects. It is a really convenient function, though, since `json_array` can actually be a generator of those objects such that the iteration through input data can be accomplished external to the extraction function (example to come with some ClinGen data loading...). So perhaps a better name might be something like "object_extract", "iteratable_extract" or even "generic_extract". I didn't make that change here since it wouldn't be backwards compatible (although there could certainly be a wrapper keeping the json_extract name to maintain compatibility.