### PR TITLE
Put `import csv` back in Common/extractor.py

### DIFF
--- a/Common/extractor.py
+++ b/Common/extractor.py
@@ -1,3 +1,4 @@
+import csv
 from Common.kgxmodel import kgxnode, kgxedge
 from Common.kgx_file_writer import KGXFileWriter
 from Common.biolink_constants import PRIMARY_KNOWLEDGE_SOURCE, AGGREGATOR_KNOWLEDGE_SOURCES


### PR DESCRIPTION
Not sure how I managed to delete this import line in my prior commit, I must have had a fumble-fingered VIM error. Sorry about that, and thanks to @Vibhorgupta31 for noticing so quickly!