### PR TITLE
Adding example edges output

### DIFF
--- a/Common/build_manager.py
+++ b/Common/build_manager.py
@@ -18,7 +18,7 @@ from Common.kgxmodel import GraphSpec, SubGraphSource, DataSource
 from Common.normalization import NORMALIZATION_CODE_VERSION, NormalizationScheme
 from Common.metadata import Metadata, GraphMetadata, SourceMetadata
 from Common.supplementation import SequenceVariantSupplementation
-from Common.meta_kg import MetaKnowledgeGraphBuilder, META_KG_FILENAME, TEST_DATA_FILENAME
+from Common.meta_kg import MetaKnowledgeGraphBuilder, META_KG_FILENAME, TEST_DATA_FILENAME, EXAMPLE_DATA_FILENAME
 from Common.redundant_kg import generate_redundant_kg
 from Common.collapse_qualifiers import generate_collapsed_qualifiers_kg
 
@@ -323,7 +323,8 @@ class GraphBuilder:
     def generate_meta_kg_and_test_data(self,
                                        graph_directory: str,
                                        generate_meta_kg: bool = True,
-                                       generate_test_data: bool = True):
+                                       generate_test_data: bool = True,
+                                       generate_example_data: bool = True):
         graph_nodes_file_path = os.path.join(graph_directory, NODES_FILENAME)
         graph_edges_file_path = os.path.join(graph_directory, EDGES_FILENAME)
         mkgb = MetaKnowledgeGraphBuilder(nodes_file_path=graph_nodes_file_path,
@@ -335,6 +336,9 @@ class GraphBuilder:
         if generate_test_data:
             test_data_file_path = os.path.join(graph_directory, TEST_DATA_FILENAME)
             mkgb.write_test_data_to_file(test_data_file_path)
+        if generate_example_data:
+            example_data_file_path = os.path.join(graph_directory, EXAMPLE_DATA_FILENAME)
+            mkgb.write_example_data_to_file(example_data_file_path)
 
     def load_graph_specs(self, graph_specs_dir=None):
         graph_spec_file = os.environ.get('ORION_GRAPH_SPEC', None)

--- a/Common/meta_kg.py
+++ b/Common/meta_kg.py
@@ -1,9 +1,6 @@
 import json
-import argparse
-import os
-from collections import defaultdict
-
 import jsonlines
+from collections import defaultdict
 
 from Common.biolink_constants import NODE_TYPES, SUBJECT_ID, OBJECT_ID, PREDICATE, PRIMARY_KNOWLEDGE_SOURCE, AGGREGATOR_KNOWLEDGE_SOURCES
 from Common.utils import quick_jsonl_file_iterator
@@ -41,7 +38,6 @@ class MetaKnowledgeGraphBuilder:
             "source_type": "primary",
             "edges": []
         }
-        self.example_nodes = {}
         self.example_edges = []
         self.analyze_nodes(nodes_file_path)
         self.analyze_edges(edges_file_path)

--- a/Common/meta_kg.py
+++ b/Common/meta_kg.py
@@ -3,6 +3,8 @@ import argparse
 import os
 from collections import defaultdict
 
+import jsonlines
+
 from Common.biolink_constants import NODE_TYPES, SUBJECT_ID, OBJECT_ID, PREDICATE, PRIMARY_KNOWLEDGE_SOURCE, AGGREGATOR_KNOWLEDGE_SOURCES
 from Common.utils import quick_jsonl_file_iterator
 from Common.biolink_utils import BiolinkUtils
@@ -14,6 +16,7 @@ BL_ATTRIBUTE_MAP = {
 
 META_KG_FILENAME = 'meta_knowledge_graph.json'
 TEST_DATA_FILENAME = 'testing_data.json'
+EXAMPLE_DATA_FILENAME = 'example_edges.jsonl'
 
 
 ####
@@ -38,6 +41,8 @@ class MetaKnowledgeGraphBuilder:
             "source_type": "primary",
             "edges": []
         }
+        self.example_nodes = {}
+        self.example_edges = []
         self.analyze_nodes(nodes_file_path)
         self.analyze_edges(edges_file_path)
 
@@ -163,6 +168,7 @@ class MetaKnowledgeGraphBuilder:
                                 for qualifier, qualifier_value in edge_qualifier_values.items()
                             ]
                         edge_type_key_to_example[edge_type_key] = example_edge
+                        self.example_edges.append(edge)
 
         for subject_node_type, object_types_to_predicates in edge_types.items():
             for object_node_type, predicates in object_types_to_predicates.items():
@@ -207,3 +213,8 @@ class MetaKnowledgeGraphBuilder:
     def write_test_data_to_file(self, output_file_path: str):
         with open(output_file_path, 'w') as test_data_file:
             test_data_file.write(json.dumps(self.testing_data, indent=4))
+
+    def write_example_data_to_file(self, output_file_path: str):
+        with open(output_file_path, 'w') as output_file_handler:
+            with jsonlines.Writer(output_file_handler) as writer:
+                writer.write_all(self.example_edges)


### PR DESCRIPTION
This creates an additional output for each graph with real example edges for each edge type in a meta knowledge graph. It looks similar to the testing_data output, but those are a different translator-specific format.