### PR TITLE
Use bagel service with gemma model for LitCoin

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 OPENAI_API_KEY=fake-key-do-not-commit-a-real-one!!!
 OPENAI_API_ORGANIZATION=fake-org-do-not-commit-a-real-one!!!
+BAGEL_SERVICE_USERNAME=fake-username-do-not-commit-a-real-one!!!
+BAGEL_SERVICE_PASSWORD=fake-password-do-not-commit-a-real-one!!!
 SHARED_SOURCE_DATA_PATH=/tmp/shared_data

--- a/Common/predicates.py
+++ b/Common/predicates.py
@@ -98,5 +98,5 @@ def call_pred_mapping(subject: str, obj: str, predicate: str, abstract: str, ret
         logger.info('Retrying predicate mapping..')
         return call_pred_mapping(subject, obj, predicate, abstract, retries + 1, logger)
 
-    # if no success after having retried 2 times  give up and return the last error
-    return {"api_error": error_message}
+    # if no success after having retried 2 times  give up and return None
+    return None

--- a/Common/predicates.py
+++ b/Common/predicates.py
@@ -81,6 +81,9 @@ def call_pred_mapping(subject: str, obj: str, predicate: str, abstract: str, ret
         else:
             error_message = f'Non-200 result from predicate mapping (url: {PRED_MAPPING_ENDPOINT}, ' \
                             f'payload: {data}). Status code: {resp_result.status_code}.'
+            if resp_result.status_code == 500 or resp_result.status_code == 403:
+                # don't retry if server raises error or denied by ingress modsec security rules
+                retries = 2
     except requests.exceptions.ConnectionError as e:
         error_message = f'Connection Error calling predicate mapping (url: {PRED_MAPPING_ENDPOINT}, ' \
                         f'payload: {data}). Error: {e}.'

--- a/docker-compose-worker.yml
+++ b/docker-compose-worker.yml
@@ -14,6 +14,8 @@ services:
       - ORION_LOGS=/ORION_logs
       - OPENAI_API_KEY=fake-key-do-not-commit-a-real-one!!!
       - OPENAI_API_ORGANIZATION=fake-org-do-not-commit-a-real-one!!!
+      - BAGEL_SERVICE_USERNAME=fake-username-do-not-commit-a-real-one!!!
+      - BAGEL_SERVICE_PASSWORD=fake-password-do-not-commit-a-real-one!!!  
       - ORION_GRAPH_SPEC
       - ORION_GRAPH_SPEC_URL
       - ORION_OUTPUT_URL

--- a/graph_specs/litcoin-graph-spec.yaml
+++ b/graph_specs/litcoin-graph-spec.yaml
@@ -12,12 +12,14 @@ graphs:
     sources:
       - source_id: LitCoin
 
-  - graph_id: LitCoin_BagelService
-    graph_name: LitCoin Bagel Service
+  - graph_id: LitCoin_ORION_BagelService
+    graph_name: LitCoin ORION Bagel Service
     graph_description: A graph for the LitCoin project using the Bagel Service
     conflation: True
     strict_normalization: True
     output_format: neo4j
+    edge_merging_attributes:
+      - abstract_id
+    edge_id_addition: True
     sources:
       - source_id: LitCoinBagelService
-        merge_strategy: dont_merge_edges

--- a/helm/orion/litcoin-worker-values.yaml
+++ b/helm/orion/litcoin-worker-values.yaml
@@ -7,7 +7,7 @@ orion:
   image:
     repository: ghcr.io/robokopu24/orion
     pullPolicy: Always
-    tag: litcoin-pipeline-worker-integration
+    tag: litcoin-pipeline
   neo4jScratchVolume:
     size: 8Gi
   resources:
@@ -27,9 +27,9 @@ orion:
     litcoinPredMappingURL: https://pred-mapping.apps.renci.org
     bl_version: 4.2.6-rc2
 
-  openAI:
-    openAIKey: fake-key-do-not-commit-a-real-one!!! 
-    openAIOrg: fake-org-do-not-commit-a-real-one!!!
+  bagel:
+    username: fake-username-do-not-commit-a-real-one!!!
+    password: fake-password-do-not-commit-a-real-one!!!
 
 # Worker-specific settings
 worker:

--- a/helm/orion/templates/config-map.yaml
+++ b/helm/orion/templates/config-map.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "orion.labels" . | nindent 4 }}
 data:
   env-file: |-
-    OPENAI_API_KEY={{ .Values.orion.openAI.openAIKey }}
-    OPENAI_API_ORGANIZATION={{ .Values.orion.openAI.openAIOrg }}
+    BAGEL_SERVICE_USERNAME={{ .Values.orion.bagel.username }}
+    BAGEL_SERVICE_PASSWORD={{ .Values.orion.bagel.password }}

--- a/helm/orion/templates/worker-deployment.yaml
+++ b/helm/orion/templates/worker-deployment.yaml
@@ -35,10 +35,10 @@ spec:
           value: /ORION_graphs
         - name: ORION_LOGS
           value: /ORION_logs
-        - name: OPENAI_API_KEY
-          value: {{ .Values.orion.openAI.openAIKey }}
-        - name: OPENAI_API_ORGANIZATION
-          value: {{ .Values.orion.openAI.openAIOrg }}
+        - name: BAGEL_SERVICE_USERNAME
+          value: {{ .Values.orion.bagel.username }}
+        - name: BAGEL_SERVICE_PASSWORD
+          value: {{ .Values.orion.bagel.password }}
         - name: LITCOIN_PRED_MAPPING_URL
           value: {{ .Values.orion.normalization.litcoinPredMappingURL }}
         - name: NODE_NORMALIZATION_ENDPOINT

--- a/parsers/LitCoin/src/bagel/bagel_service.py
+++ b/parsers/LitCoin/src/bagel/bagel_service.py
@@ -1,4 +1,5 @@
 import requests
+from requests.auth import HTTPBasicAuth
 from Common.config import CONFIG
 
 BAGEL_ENDPOINT = 'https://bagel.apps.renci.org/'
@@ -13,10 +14,10 @@ bagel_sapbert_url += "annotate/"
 bagel_nodenorm_url = CONFIG.get('NODE_NORMALIZATION_ENDPOINT', 'https://nodenormalization-sri.renci.org/')
 bagel_nodenorm_url += 'get_normalized_nodes'
 
-OPENAI_API_KEY = CONFIG.get("OPENAI_API_KEY")
-assert OPENAI_API_KEY
-OPENAI_API_ORGANIZATION = CONFIG.get("OPENAI_API_ORGANIZATION")
-assert OPENAI_API_ORGANIZATION
+BAGEL_SERVICE_USERNAME = CONFIG.get("BAGEL_SERVICE_USERNAME")
+assert BAGEL_SERVICE_USERNAME
+BAGEL_SERVICE_PASSWORD = CONFIG.get("BAGEL_SERVICE_PASSWORD")
+assert BAGEL_SERVICE_PASSWORD
 
 
 def call_bagel_service(text, entity, entity_type=''):
@@ -27,11 +28,12 @@ def call_bagel_service(text, entity, entity_type=''):
         "entity": entity,
         "entity_type": entity_type,
         "config": {
-            "llm_model_name": "gpt-4o-mini",
-            "organization": OPENAI_API_ORGANIZATION,
-            "access_key": OPENAI_API_KEY,
+            "llm_model_name": "google/gemma-3-12b-it",
+            "organization": "",
+            "access_key": "",
+            "url": "http://vllm-server/v1",
             "llm_model_args": {
-              "top_p": 0,
+              "top_p": 0.1,
               "temperature": 0.1
             }
         },
@@ -41,6 +43,7 @@ def call_bagel_service(text, entity, entity_type=''):
     }
     # print(f'Querying bagel with:\n {bagel_json}')
     bagel_response = requests.post(BAGEL_ENDPOINT,
+                                   auth=HTTPBasicAuth(BAGEL_SERVICE_USERNAME, BAGEL_SERVICE_PASSWORD),
                                    json=bagel_json)
 
     if bagel_response.status_code == 200:


### PR DESCRIPTION
This PR contains improvement for calling predicate mapping service as well as using the bagel service for node normalization for LitCoin and replacing OpenAI model with google's gemma 3 model.