### PR TITLE
Merging metadata

### DIFF
--- a/orion/graph_pipeline.py
+++ b/orion/graph_pipeline.py
@@ -133,6 +133,8 @@ class GraphBuilder:
                                   f'{merge_metadata["merge_error"]}')
                 # Leave the incomplete dir behind; the next run clears and retries it.
                 return False
+            
+            source_merger.write_merge_metadata(graph_output_dir)
 
             # ISO 8601 in UTC, the format graph metadata dates are recorded in
             build_time = (datetime.datetime.now(datetime.timezone.utc)

--- a/orion/graph_pipeline.py
+++ b/orion/graph_pipeline.py
@@ -133,7 +133,9 @@ class GraphBuilder:
                                   f'{merge_metadata["merge_error"]}')
                 # Leave the incomplete dir behind; the next run clears and retries it.
                 return False
-            
+
+            # Merge metadata is generated during the merge and cannot be recreated from plain KGX files
+            # so it has to written here and can't be generated after the fact like other metadata below.
             source_merger.write_merge_metadata()
 
             # ISO 8601 in UTC, the format graph metadata dates are recorded in

--- a/orion/graph_pipeline.py
+++ b/orion/graph_pipeline.py
@@ -134,7 +134,7 @@ class GraphBuilder:
                 # Leave the incomplete dir behind; the next run clears and retries it.
                 return False
             
-            source_merger.write_merge_metadata(graph_output_dir)
+            source_merger.write_merge_metadata()
 
             # ISO 8601 in UTC, the format graph metadata dates are recorded in
             build_time = (datetime.datetime.now(datetime.timezone.utc)

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -1,6 +1,7 @@
 import os
 import gzip
 import json
+from collections import Counter
 from datetime import datetime
 from orion.utils import quick_jsonl_file_iterator
 from orion.logging import get_orion_logger
@@ -106,9 +107,9 @@ class KGXFileMerger:
             self.merge_metadata['edges_diff'] += self.edge_graph_merger.merged_edge_counter
             for merger in (self.node_graph_merger, self.edge_graph_merger):
                 for warning_type in ('mismatched_properties', 'dropped_properties'):
-                    existing = set(self.merge_metadata['merge_warnings'][warning_type])
+                    existing = Counter(self.merge_metadata['merge_warnings'][warning_type])
                     existing.update(merger.merge_warnings[warning_type])
-                    self.merge_metadata['merge_warnings'][warning_type] = sorted(existing)
+                    self.merge_metadata['merge_warnings'][warning_type] = dict(existing.most_common())
 
     def merge_primary_sources(self,
                               graph_sources: list):
@@ -265,8 +266,8 @@ class KGXFileMerger:
                 'pre_merge_edges_merged': 0,
                 'post_merge_edges_merged': 0,
                 'edges_diff': 0,
-                'merge_warnings': {'mismatched_properties': [],
-                                   'dropped_properties': []},
+                'merge_warnings': {'mismatched_properties': {},
+                                   'dropped_properties': {}},
                 'final_node_count': 0,
                 'final_edge_count': 0}
 

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -12,6 +12,9 @@ from orion.data_sources import RESOURCE_HOGS
 
 logger = get_orion_logger("orion.kgx_file_merger")
 
+# metadata about what happened in a merge, to be written next to the graph it produced.
+MERGE_METADATA_FILENAME = 'merge-metadata.json'
+
 class KGXFileMerger:
 
     CONNECTED_EDGE_SUBSET = 'connected_edge_subset'
@@ -273,6 +276,20 @@ class KGXFileMerger:
 
     def get_merge_metadata(self):
         return self.merge_metadata
+
+    # Write the merge metadata to MERGE_METADATA_FILENAME in output_directory.
+    # kgx_graph_metadata is left out, that's the entire graph-metadata.json for the source
+    # already included with graph outputs, not relevant for merging metadata
+    def write_merge_metadata(self, output_directory: str = None):
+        merge_metadata = dict(self.merge_metadata)
+        merge_metadata['sources'] = {
+            source_id: {key: value for key, value in source_metadata.items() if key != 'kgx_graph_metadata'}
+            for source_id, source_metadata in merge_metadata['sources'].items()
+        }
+        merge_metadata_path = os.path.join(output_directory or self.output_directory, MERGE_METADATA_FILENAME)
+        with open(merge_metadata_path, 'w') as merge_metadata_file:
+            json.dump(merge_metadata, merge_metadata_file, indent=2)
+        return merge_metadata_path
 
 
 # This was moved over from the cli implementation - it's a hacky way to merge files without a graph spec

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -51,9 +51,11 @@ class KGXFileMerger:
         secondary_sources = []
         dont_merge_sources = []
         for graph_source in resolved_sources:
+            source_metadata = graph_source.get_metadata_representation()
+            # the sources here are keyed by id, so the id in the source's own representation is redundant
+            source_metadata.pop('id')
             self.merge_metadata["sources"][graph_source.id] = {
-                'release_version': graph_source.release_version,
-                'build_version': graph_source.build_version,
+                **source_metadata,
                 'kgx_graph_metadata': graph_source.kgx_graph_metadata,
                 'node_count': 0,
                 'edge_count': 0,

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -91,8 +91,8 @@ class KGXFileMerger:
             self.merge_metadata['unmerged_edge_count'] = unmerged_edges_written
             self.merge_metadata['final_node_count'] += merged_nodes_written
             self.merge_metadata['final_edge_count'] += merged_edges_written + unmerged_edges_written
-            self.merge_metadata['merged_nodes'] += self.node_graph_merger.merged_node_counter
-            self.merge_metadata['merged_edges'] += self.edge_graph_merger.merged_edge_counter
+            self.merge_metadata['nodes_diff'] += self.node_graph_merger.merged_node_counter
+            self.merge_metadata['edges_diff'] += self.edge_graph_merger.merged_edge_counter
             for merger in (self.node_graph_merger, self.edge_graph_merger):
                 for warning_type in ('mismatched_properties', 'dropped_properties'):
                     existing = set(self.merge_metadata['merge_warnings'][warning_type])
@@ -248,8 +248,8 @@ class KGXFileMerger:
     def init_merge_metadata():
         return {'sources': {},
                 'merging_code_version': MERGING_CODE_VERSION,
-                'merged_nodes': 0,
-                'merged_edges': 0,
+                'nodes_diff': 0,
+                'edges_diff': 0,
                 'merge_warnings': {'mismatched_properties': [],
                                    'dropped_properties': []},
                 'final_node_count': 0,

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -282,13 +282,13 @@ class KGXFileMerger:
     # Write the merge metadata to MERGE_METADATA_FILENAME in output_directory.
     # kgx_graph_metadata is left out, that's the entire graph-metadata.json for the source
     # already included with graph outputs, not relevant for merging metadata
-    def write_merge_metadata(self, output_directory: str = None):
+    def write_merge_metadata(self):
         merge_metadata = dict(self.merge_metadata)
         merge_metadata['sources'] = {
             source_id: {key: value for key, value in source_metadata.items() if key != 'kgx_graph_metadata'}
             for source_id, source_metadata in merge_metadata['sources'].items()
         }
-        merge_metadata_path = os.path.join(output_directory or self.output_directory, MERGE_METADATA_FILENAME)
+        merge_metadata_path = os.path.join(self.output_directory, MERGE_METADATA_FILENAME)
         with open(merge_metadata_path, 'w') as merge_metadata_file:
             json.dump(merge_metadata, merge_metadata_file, indent=2)
         return merge_metadata_path

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -91,7 +91,18 @@ class KGXFileMerger:
             self.merge_metadata['unmerged_edge_count'] = unmerged_edges_written
             self.merge_metadata['final_node_count'] += merged_nodes_written
             self.merge_metadata['final_edge_count'] += merged_edges_written + unmerged_edges_written
+            # Merging is reported three ways: how many entities went in to a merge (pre_merge_*_merged),
+            # how many came out of one (post_merge_*_merged), and the difference between those, which is
+            # how many entities disappeared because of merging (*_diff).
+            merged_node_groups = self.node_graph_merger.merged_node_group_counter
+            merged_edge_groups = self.edge_graph_merger.merged_edge_group_counter
+            self.merge_metadata['pre_merge_nodes_merged'] += (self.node_graph_merger.merged_node_counter
+                                                              + merged_node_groups)
+            self.merge_metadata['post_merge_nodes_merged'] += merged_node_groups
             self.merge_metadata['nodes_diff'] += self.node_graph_merger.merged_node_counter
+            self.merge_metadata['pre_merge_edges_merged'] += (self.edge_graph_merger.merged_edge_counter
+                                                              + merged_edge_groups)
+            self.merge_metadata['post_merge_edges_merged'] += merged_edge_groups
             self.merge_metadata['edges_diff'] += self.edge_graph_merger.merged_edge_counter
             for merger in (self.node_graph_merger, self.edge_graph_merger):
                 for warning_type in ('mismatched_properties', 'dropped_properties'):
@@ -248,7 +259,11 @@ class KGXFileMerger:
     def init_merge_metadata():
         return {'sources': {},
                 'merging_code_version': MERGING_CODE_VERSION,
+                'pre_merge_nodes_merged': 0,
+                'post_merge_nodes_merged': 0,
                 'nodes_diff': 0,
+                'pre_merge_edges_merged': 0,
+                'post_merge_edges_merged': 0,
                 'edges_diff': 0,
                 'merge_warnings': {'mismatched_properties': [],
                                    'dropped_properties': []},

--- a/orion/kgxmodel.py
+++ b/orion/kgxmodel.py
@@ -149,11 +149,6 @@ class GraphFileSource:
     build_version: str = None
     kgx_graph_metadata: dict = None
 
-    @property
-    def version_identifier(self) -> str | None:
-        """release_version when set (built graphs / subgraphs), else build_version (raw parser output)."""
-        return self.release_version or self.build_version
-
     def get_node_file_paths(self):
         if self.file_paths is None:
             raise Exception(f'File paths were requested before they were established for GraphFileSource {self.id}')

--- a/orion/kgxmodel.py
+++ b/orion/kgxmodel.py
@@ -136,12 +136,11 @@ class GraphFileSource:
     pulled from the registry, built as a subgraph, or just-materialized from
     an ingest pipeline run).
 
-    Exactly one of release_version / build_version is set, depending on what
-    this source represents:
-    - release_version (semver): for built graphs and subgraphs.
-    - build_version (hash):     for raw parser output coming straight from
-                                the ingest pipeline, or for a single-source
-                                graph matched by its source's build hash.
+    A build_version (hash) is always set. A release_version (semver) accompanies it
+    for anything resolved from a bundle, taken from the release the bundle
+    records for itself when the spec didn't pin one. Raw parser output coming
+    straight from the ingest pipeline has no release and carries only
+    build_version.
     """
     id: str
     file_paths: list

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -190,8 +190,13 @@ class GraphMerger:
                  add_edge_id=False,
                  edge_id_type=None,
                  overwrite_edge_ids=True):
+        # merged_*_counter counts how many entities merged/disappeared into another one
         self.merged_node_counter = 0
         self.merged_edge_counter = 0
+        # merged_*_group_counter counts the number of sets of merged entities
+        # or, how many merged entities exist after merging
+        self.merged_node_group_counter = 0
+        self.merged_edge_group_counter = 0
         self.merge_warnings = {'mismatched_properties': set(), 'dropped_properties': set()}
         self.edge_merging_attributes = edge_merging_attributes
         self.add_edge_id = add_edge_id
@@ -390,8 +395,10 @@ class DiskGraphMerger(GraphMerger):
             return
         file_handlers = [open(file_path) for file_path in file_paths]
 
-        # store a string that can be used to reference the counter for the appropriate entity type
+        # store strings that can be used to reference the counters for the appropriate entity type
         merge_counter = 'merged_node_counter' if entity_type == NODE_ENTITY_TYPE else 'merged_edge_counter'
+        group_counter = 'merged_node_group_counter' if entity_type == NODE_ENTITY_TYPE \
+            else 'merged_edge_group_counter'
 
         # Here we use a min-heap to organize iterating through the entity files to compare their keys and merge entities
         # with matching keys. Members of the heap are tuples representing each line from a file:
@@ -459,6 +466,7 @@ class DiskGraphMerger(GraphMerger):
 
             # If we did a merge we need to convert back to a json string for writing, and apply a new id if desired
             if merged_entity is not None:
+                setattr(self, group_counter, getattr(self, group_counter) + 1)
                 if track_pre_merge_ids:
                     # It looks like we're overwriting all edge ids, but you don't get here without a merge occurring
                     merged_entity[EDGE_ID] = min_key
@@ -501,6 +509,9 @@ class MemoryGraphMerger(GraphMerger):
                          overwrite_edge_ids=overwrite_edge_ids)
         self.nodes = {}
         self.edges = {}
+        # store the keys of nodes/edges that are actually involved in mergers for metadata counts
+        self.merged_node_keys = set()
+        self.merged_edge_keys = set()
         self.pre_merge_edge_id_mapping = defaultdict(list)
         self.pre_merge_mapping_file_path = pre_merge_mapping_file_path
 
@@ -516,6 +527,7 @@ class MemoryGraphMerger(GraphMerger):
         node_key = node['id']
         if node_key in self.nodes:
             self.merged_node_counter += 1
+            self.merged_node_keys.add(node_key)
             previous_node = self.nodes[node_key]
             merged_node = entity_merging_function(previous_node,
                                                   node)
@@ -536,6 +548,7 @@ class MemoryGraphMerger(GraphMerger):
                                      edge_id_type=self.edge_id_type)
         if edge_key in self.edges:
             self.merged_edge_counter += 1
+            self.merged_edge_keys.add(edge_key)
             existing_edge = quick_json_loads(self.edges[edge_key])
             if self.add_edge_id and not self.overwrite_edge_ids:
                 mapping = self.pre_merge_edge_id_mapping
@@ -563,6 +576,7 @@ class MemoryGraphMerger(GraphMerger):
     def get_merged_nodes_jsonl(self):
         for node in self.nodes.values():
             yield f'{quick_json_dumps(node)}\n'
+        self.merged_node_group_counter = len(self.merged_node_keys)
         self._record_merge_warnings(flush_merge_warnings())
 
     def get_merged_edges_jsonl(self):
@@ -572,6 +586,7 @@ class MemoryGraphMerger(GraphMerger):
             with open(self.pre_merge_mapping_file_path, 'w') as f:
                 for post_merge_id, pre_merge_ids in self.pre_merge_edge_id_mapping.items():
                     f.write(f'{quick_json_dumps({"post_merge_id": post_merge_id, "pre_merge_ids": pre_merge_ids})}\n')
+        self.merged_edge_group_counter = len(self.merged_edge_keys)
         self._record_merge_warnings(flush_merge_warnings())
 
     def get_pre_merge_edge_id_mapping(self):

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -1,7 +1,7 @@
 import heapq
 import os
 import secrets
-from collections import defaultdict
+from collections import defaultdict, Counter
 import uuid_utils as uuid
 from xxhash import xxh64_hexdigest
 from orion.biolink_utils import BiolinkUtils
@@ -22,15 +22,16 @@ logger = get_orion_logger("orion.merging")
 
 MERGING_CODE_VERSION = '2.0.0'
 
-# mismatches where one entity has a dict for a property and another has another type.
-_mismatched_dict_properties = set()
-# properties where two entities had different values that could not be reconciled.
-_dropped_properties = set()
+# how many times a property was a dict on one entity and another type on another entity.
+_mismatched_dict_properties = Counter()
+# how many times two entities had different values for a property that could not be reconciled.
+_dropped_properties = Counter()
 
-# Emit collected warnings, clear them, and return the collected lists for metadata capture.
+# Emit collected warnings, clear them, and return the collected counts for metadata capture.
 def flush_merge_warnings():
-    mismatched = sorted(_mismatched_dict_properties)
-    dropped = sorted(_dropped_properties)
+    # most_common orders by count descending, so the worst offenders come first
+    mismatched = dict(_mismatched_dict_properties.most_common())
+    dropped = dict(_dropped_properties.most_common())
     if mismatched:
         logger.warning(f'Mismatched types encountered while merging properties: '
                        f'{mismatched}. Some instances were dictionaries and some were not. Mismatches were discarded.')
@@ -128,11 +129,11 @@ def entity_merging_function(entity_1, entity_2):
                             pass  # keep entity_1; sub_value is falsy
                         elif existing_sub_value != sub_value:
                             # both truthy and differ; keep entity_1 and record the drop
-                            _dropped_properties.add(key)
+                            _dropped_properties[key] += 1
                     else:
                         entity_1_value[sub_key] = sub_value
             elif entity_1_is_dict or entity_2_is_dict:
-                _mismatched_dict_properties.add(key)
+                _mismatched_dict_properties[key] += 1
             elif entity_1_is_list and entity_2_is_list:
                 # if they're both lists just concat them
                 entity_1_value.extend(entity_2_value)
@@ -154,7 +155,7 @@ def entity_merging_function(entity_1, entity_2):
                     pass  # keep entity_1; entity_2 is falsy, nothing meaningful to drop
                 elif entity_1_value != entity_2_value:
                     # both truthy and differ; keep entity_1 and record that entity_2 was dropped
-                    _dropped_properties.add(key)
+                    _dropped_properties[key] += 1
 
             # if either was a list remove duplicate values
             if entity_1_is_list or entity_2_is_list:
@@ -197,7 +198,7 @@ class GraphMerger:
         # or, how many merged entities exist after merging
         self.merged_node_group_counter = 0
         self.merged_edge_group_counter = 0
-        self.merge_warnings = {'mismatched_properties': set(), 'dropped_properties': set()}
+        self.merge_warnings = {'mismatched_properties': Counter(), 'dropped_properties': Counter()}
         self.edge_merging_attributes = edge_merging_attributes
         self.add_edge_id = add_edge_id
         self.edge_id_type = edge_id_type
@@ -236,6 +237,7 @@ class GraphMerger:
         raise NotImplementedError
 
     def _record_merge_warnings(self, warnings):
+        # merge_warnings are Counters, so update adds incoming counts to existing ones
         self.merge_warnings['mismatched_properties'].update(warnings['mismatched_properties'])
         self.merge_warnings['dropped_properties'].update(warnings['dropped_properties'])
 

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -529,8 +529,8 @@ class MemoryGraphMerger(GraphMerger):
         node_key = node['id']
         if node_key in self.nodes:
             self.merged_node_counter += 1
-            self.merged_node_keys.add(node_key)
             previous_node = self.nodes[node_key]
+            self.merged_node_keys.add(previous_node['id'])
             merged_node = entity_merging_function(previous_node,
                                                   node)
             self.nodes[node_key] = merged_node

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -24,7 +24,9 @@ MERGING_CODE_VERSION = '2.0.0'
 
 # how many times a property was a dict on one entity and another type on another entity.
 _mismatched_dict_properties = Counter()
-# how many times two entities had different values for a property that could not be reconciled.
+# how many values were discarded because two entities had a different value for a property that
+# could not be reconciled. A property whose value is a dictionary counts every conflicting
+# key inside it, so these are counts of values lost, not counts of merges affected.
 _dropped_properties = Counter()
 
 # Emit collected warnings, clear them, and return the collected counts for metadata capture.

--- a/orion/source_resolution.py
+++ b/orion/source_resolution.py
@@ -87,13 +87,17 @@ class SourceResolver:
         bundle = KGXBundle(graph_dir)
         if not (bundle.has_nodes_and_edges() and bundle.has_graph_metadata()):
             return None
+        kgx_graph_metadata = bundle.load_graph_metadata()
         return GraphFileSource(
             id=source.id,
-            release_version=source.release_version,
+            # A source pinned to a release_version already has one. Otherwise, it was resolved by
+            # build_version, and the release that build belongs to is the one the bundle recorded
+            # for itself when it was built.
+            release_version=source.release_version or kgx_graph_metadata.get('version'),
             build_version=build_version,
             file_paths=[bundle.nodes_path, bundle.edges_path],
             merge_strategy=source.merge_strategy,
-            kgx_graph_metadata=bundle.load_graph_metadata(),
+            kgx_graph_metadata=kgx_graph_metadata,
         )
 
     def _resolve_registry(self, source: GraphSource) -> GraphFileSource | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "robokop-orion"
-version = "2.0.4"
+version = "2.0.5"
 description = "ORION ingests data from knowledge bases and converts it into interoperable Biolink Model knowledge graphs."
 license = "MIT"
 license-files = ["LICEN[CS]E*"]

--- a/tests/test_build_graph_end_to_end.py
+++ b/tests/test_build_graph_end_to_end.py
@@ -275,6 +275,24 @@ def test_build_graph_end_to_end_multi_source(tmp_path, monkeypatch):
         merged_edges = [json.loads(line) for line in f]
     assert len(merged_edges) == 3  # two HGNC + one CTD
 
+    # --- merge-metadata.json records what the merge did ---
+    with open(parent_dir / 'merge-metadata.json') as f:
+        merge_metadata = json.load(f)
+    assert set(merge_metadata['sources']) == {'HGNC', 'CTD'}
+    assert merge_metadata['sources']['HGNC']['node_count'] == 3
+    assert merge_metadata['sources']['CTD']['node_count'] == 2
+    assert merge_metadata['final_node_count'] == 4
+    assert merge_metadata['final_edge_count'] == 3
+    # HGNC:2 arrives from both sources, so two nodes merged into one and one node disappeared
+    assert merge_metadata['pre_merge_nodes_merged'] == 2
+    assert merge_metadata['post_merge_nodes_merged'] == 1
+    assert merge_metadata['nodes_diff'] == 1
+    # no edge is duplicated across the sources
+    assert merge_metadata['pre_merge_edges_merged'] == 0
+    assert merge_metadata['post_merge_edges_merged'] == 0
+    assert merge_metadata['edges_diff'] == 0
+    assert merge_metadata['merge_warnings'] == {'mismatched_properties': {}, 'dropped_properties': {}}
+
     # --- Each contributing source is itself a single-source graph bundle at
     # graphs_dir/<source_id>/<build_version>/, produced by the same build path as any graph and
     # consumed by the parent merger. ---
@@ -285,6 +303,7 @@ def test_build_graph_end_to_end_multi_source(tmp_path, monkeypatch):
         assert (source_build_dir / 'nodes.jsonl.gz').exists()
         assert (source_build_dir / 'edges.jsonl.gz').exists()
         assert (source_build_dir / 'qc-results.json').exists()
+        assert (source_build_dir / 'merge-metadata.json').exists()
         build_metadata_path = source_build_dir / 'graph-metadata.json'
         assert build_metadata_path.exists()
         with open(build_metadata_path) as f:

--- a/tests/test_build_graph_end_to_end.py
+++ b/tests/test_build_graph_end_to_end.py
@@ -309,6 +309,10 @@ def test_build_graph_end_to_end_multi_source(tmp_path, monkeypatch):
         with open(build_metadata_path) as f:
             build_metadata = json.load(f)
 
+        # the parent's merge metadata identifies each source by both of the versions it was built as
+        assert merge_metadata['sources'][source_id]['build_version'] == source_resolved.build_version
+        assert merge_metadata['sources'][source_id]['release_version'] == build_metadata['version']
+
         distribution_urls = {entry['contentUrl'] for entry in build_metadata['distribution']}
         graph_dir_url_suffix = f'/{source_id}/{build_metadata["version"]}/'
         assert any(url.endswith(f'{graph_dir_url_suffix}nodes.jsonl.gz') for url in distribution_urls)

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -745,7 +745,7 @@ def truthy_scalar_collision_test(graph_merger: GraphMerger):
     # only the genuine truthy/truthy collision should be recorded as dropped;
     # falsy-vs-truthy and equal-value merges must not show up here
     dropped = graph_merger.merge_warnings['dropped_properties']
-    assert 'conflicting' in dropped
+    assert dropped['conflicting'] == 1
     for name in ('zero_then_int', 'empty_then_str', 'none_then_str',
                  'int_then_zero', 'str_then_empty', 'str_then_none', 'agreeing'):
         assert name not in dropped
@@ -757,3 +757,29 @@ def test_truthy_scalar_collision_in_memory():
 
 def test_truthy_scalar_collision_on_disk(tmp_path):
     truthy_scalar_collision_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4))
+
+
+def dropped_property_counts_test(graph_merger: GraphMerger):
+    # every merge of these edges drops a conflicting value, so the counts should reflect
+    # how many times each property was affected, not just which properties were affected
+    test_edges = [make_edge(1, 2, **{'often_dropped': f'value_{i}', 'agreeing': 'same'})
+                  for i in range(5)]
+    test_edges += [make_edge(3, 4, **{'rarely_dropped': f'value_{i}'}) for i in range(2)]
+    # a dict on one edge and a scalar on another is a mismatch, not a drop
+    test_edges += [make_edge(5, 6, **{'mismatched': {'a': 1}}), make_edge(5, 6, **{'mismatched': 'not_a_dict'})]
+
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(edge) for edge in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 3
+
+    # the first edge of each set isn't dropping anything, so 5 edges means 4 drops
+    assert graph_merger.merge_warnings['dropped_properties'] == {'often_dropped': 4, 'rarely_dropped': 1}
+    assert graph_merger.merge_warnings['mismatched_properties'] == {'mismatched': 1}
+
+
+def test_dropped_property_counts_in_memory():
+    dropped_property_counts_test(MemoryGraphMerger())
+
+
+def test_dropped_property_counts_on_disk(tmp_path):
+    dropped_property_counts_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4))

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -1,4 +1,6 @@
 from orion.merging import GraphMerger, MemoryGraphMerger, DiskGraphMerger, NODE_ENTITY_TYPE, EDGE_ENTITY_TYPE
+from orion.kgx_file_merger import KGXFileMerger, MERGE_METADATA_FILENAME
+from orion.kgxmodel import GraphSpec, GraphFileSource
 from orion.biolink_constants import *
 import os
 import json
@@ -783,3 +785,62 @@ def test_dropped_property_counts_in_memory():
 
 def test_dropped_property_counts_on_disk(tmp_path):
     dropped_property_counts_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4))
+
+
+def test_merge_metadata_records_each_source(tmp_path):
+    # KGXFileMerger describes every source it merged, including how that source joined the graph
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    def write_source(source_id, nodes, edges):
+        nodes_path = input_dir / f'{source_id}_nodes.jsonl'
+        edges_path = input_dir / f'{source_id}_edges.jsonl'
+        for path, rows in ((nodes_path, nodes), (edges_path, edges)):
+            with open(path, 'w') as f:
+                for row in rows:
+                    f.write(json.dumps(row) + '\n')
+        return [str(nodes_path), str(edges_path)]
+
+    primary_files = write_source('primary', [make_node(1), make_node(2)], [make_edge(1, 2)])
+    # a dont_merge source contributes its edges without them taking part in merging at all
+    unmerged_files = write_source('unmerged', [make_node(2), make_node(3)], [make_edge(2, 3)])
+
+    graph_spec = GraphSpec(graph_id='test_graph', graph_name='', graph_description='', graph_url='',
+                           graph_output_format='jsonl', sources=[],
+                           resolved_sources=[
+                               GraphFileSource(id='primary',
+                                               release_version='1.0.0',
+                                               build_version='abc123',
+                                               file_paths=primary_files),
+                               GraphFileSource(id='unmerged',
+                                               release_version='2.1.0',
+                                               build_version='def456',
+                                               file_paths=unmerged_files,
+                                               merge_strategy=KGXFileMerger.DONT_MERGE)])
+    file_merger = KGXFileMerger(graph_spec=graph_spec,
+                                output_directory=str(output_dir),
+                                nodes_output_filename='nodes.jsonl',
+                                edges_output_filename='edges.jsonl')
+    file_merger.merge()
+    file_merger.write_merge_metadata()
+
+    with open(output_dir / MERGE_METADATA_FILENAME) as f:
+        merge_metadata = json.load(f)
+
+    assert merge_metadata['sources']['primary'] == {'release_version': '1.0.0',
+                                                    'build_version': 'abc123',
+                                                    'merge_strategy': None,
+                                                    'node_count': 2,
+                                                    'edge_count': 1,
+                                                    'files': {'primary_nodes.jsonl': {'nodes': 2},
+                                                              'primary_edges.jsonl': {'edges': 1}}}
+    assert merge_metadata['sources']['unmerged']['merge_strategy'] == KGXFileMerger.DONT_MERGE
+    assert merge_metadata['sources']['unmerged']['release_version'] == '2.1.0'
+    # NODE:2 came from both sources, and the dont_merge source's edge was appended unmerged
+    assert merge_metadata['final_node_count'] == 3
+    assert merge_metadata['final_edge_count'] == 2
+    assert merge_metadata['unmerged_edge_count'] == 1
+    assert merge_metadata['pre_merge_nodes_merged'] == 2
+    assert merge_metadata['post_merge_nodes_merged'] == 1

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -53,7 +53,9 @@ def node_merging_counts_test(graph_merger: GraphMerger):
 
     merged_node_lines = list(graph_merger.get_merged_nodes_jsonl())
     assert len(merged_node_lines) == 25
+    # nodes 6 through 20 were each provided twice, so 15 sets of 2 nodes merged
     assert graph_merger.merged_node_counter == 15
+    assert graph_merger.merged_node_group_counter == 15
 
 
 def test_node_merging_counts_in_memory():
@@ -250,7 +252,45 @@ def edge_merging_counts_test(graph_merger: GraphMerger):
             assert len(edge['string_list_property']) == 1
         assert edge['int_property'] == int(edge[SUBJECT_ID].split(':')[1]) or edge['int_property'] == 999999
 
+    # edges 6 through 10 were provided twice for each of the two predicates, so 10 sets of 2 edges merged
     assert graph_merger.merged_edge_counter == 10
+    assert graph_merger.merged_edge_group_counter == 10
+
+
+def merged_group_counts_test(graph_merger: GraphMerger):
+    # merged sets of varying sizes - one set of 4 nodes/edges, one set of 2, and two that never merge
+    duplicated_4 = [make_node(1, **{'testing_prop': [i]}) for i in range(4)]
+    duplicated_2 = [make_node(2, **{'testing_prop': [i]}) for i in range(2)]
+    unique_nodes = [make_node(3), make_node(4)]
+    input_node_count = graph_merger.merge_nodes(duplicated_4 + duplicated_2 + unique_nodes)
+
+    duplicated_4 = [make_edge(1, 2, **{'testing_prop': [i]}) for i in range(4)]
+    duplicated_2 = [make_edge(3, 4, **{'testing_prop': [i]}) for i in range(2)]
+    unique_edges = [make_edge(5, 6), make_edge(7, 8)]
+    input_edge_count = graph_merger.merge_edges(duplicated_4 + duplicated_2 + unique_edges)
+
+    output_node_count = len(list(graph_merger.get_merged_nodes_jsonl()))
+    output_edge_count = len(list(graph_merger.get_merged_edges_jsonl()))
+    assert input_node_count == 8 and output_node_count == 4
+    assert input_edge_count == 8 and output_edge_count == 4
+
+    # 6 nodes/edges went in to a merge and 2 came out of one, the difference is what merging removed
+    for merged_counter, group_counter, input_count, output_count in (
+            (graph_merger.merged_node_counter, graph_merger.merged_node_group_counter,
+             input_node_count, output_node_count),
+            (graph_merger.merged_edge_counter, graph_merger.merged_edge_group_counter,
+             input_edge_count, output_edge_count)):
+        assert group_counter == 2
+        assert merged_counter + group_counter == 6
+        assert merged_counter == input_count - output_count
+
+
+def test_merged_group_counts_in_memory():
+    merged_group_counts_test(MemoryGraphMerger())
+
+
+def test_merged_group_counts_on_disk(tmp_path):
+    merged_group_counts_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=3))
 
 
 def test_edge_merging_counts_in_memory():
@@ -286,7 +326,9 @@ def test_qualifier_edge_merging():
 
     merged_edges = [json.loads(edge) for edge in graph_merger.get_merged_edges_jsonl()]
     assert len(merged_edges) == 3
+    # 30 edges merged down to 3 sets, distinguished by their qualifiers
     assert graph_merger.merged_edge_counter == 27
+    assert graph_merger.merged_edge_group_counter == 3
 
     passed_tests = 0
     for edge in merged_edges:


### PR DESCRIPTION
This improves merging metadata in several ways:
-  Adds new fields (pre_merge_nodes/edges_merged and post_merge_nodes/edges_merged) stating explicitly how many entity mergers occurred, not just the total number of entities that were merged into other entities.
- Renamed the confusing "merged_edges" and "merged_nodes" keys to the more precise "edges_diff" and "nodes_diff" 
- The merge_warnings section now includes explicit counts for how many instances of mismatched_properties and dropped_properties occurred instead of just listing the property names.
- Merge-metadata now includes the entire metadata representation of GraphFileSource. Some of these fields were added in ORION previously but translator has not been brought up to the latest version yet. When it is the merge metadata will include the build and release versions and any merge strategies utilized. 

This also brought back writing merge metadata to graph output directories for ORION ROBOKOP graphs, which had previously been turned off while redesigning the ingest and release pipeline.

MERGING_CODE_VERSION is deliberately unchanged because the actual KGX outputs will not change from this PR, only metadata. The metadata is currently not consumed programmatically anywhere, so I think we're ok waiting until the next graphs are built for it to update.

Addresses https://github.com/NCATSTranslator/translator-ingests/issues/373